### PR TITLE
Missing SESSION global in auth.php

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -190,7 +190,7 @@ class auth_plugin_mcae extends auth_plugin_base {
      * @param string $password plain text password (with system magic quotes)
      */
     function user_authenticated_hook(&$user, $username, $password) {
-	global $DB;
+	global $DB, $SESSION;
 
         $context = get_context_instance(CONTEXT_SYSTEM);
         $uid = $user->id;


### PR DESCRIPTION
The file auth.php is missing the declaration for the global $SESSION in the user_authenticated_hook function.  This results in a strict standards notice being logged every time a user logs in.
