### PR TITLE
auth_mcae: Update context calls to use the new API

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -189,7 +189,7 @@ class auth_plugin_mcae extends auth_plugin_base {
     function user_authenticated_hook(&$user, $username, $password) {
 	global $DB, $SESSION;
 
-        $context = get_context_instance(CONTEXT_SYSTEM);
+        $context = context_system::instance();
         $uid = $user->id;
         // Ignore users from don't_touch list
         $ignore = explode(",",$this->config->donttouchusers);

--- a/convert.php
+++ b/convert.php
@@ -15,7 +15,7 @@ require_once($CFG->libdir . '/adminlib.php');
 
 require_login();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 $returnurl = new moodle_url('/auth/mcae/convert.php');
 
 admin_externalpage_setup('cohorttoolmcae');

--- a/view.php
+++ b/view.php
@@ -16,7 +16,7 @@ require_login();
 
 admin_externalpage_setup('cohortviewmcae');
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 require_capability('moodle/cohort:view', $context, $USER->id);
 


### PR DESCRIPTION
auth_mcae is displaying depreciated function notices for the calls to get_context_instance (depreciated in Moodle 2.6)
