### PR TITLE
Made line break platform independent

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -157,7 +157,7 @@ class auth_plugin_mcae extends auth_plugin_manual {
 
         $replacements = array();
         if (!empty($replacementstemplate)) {
-            $replacementsarray = explode($delim, $replacementstemplate);
+            $replacementsarray = preg_split('/\r\n|\r|\n/', $replacementstemplate);
             foreach ($replacementsarray as $replacement) {
                 list($key, $val) = explode("|", $replacement);
                 $replacements[$key] = $val;
@@ -170,7 +170,7 @@ class auth_plugin_mcae extends auth_plugin_manual {
         $mainrulearray = array();
         $templates = array();
         if (!empty($mainrule)) {
-            $mainrulearray = explode($delim, $mainrule);
+            $mainrulearray = preg_split('/\r\n|\r|\n/', $mainrule);
         } else {
             $SESSION->mcautoenrolled = true;
             return; // Empty mainrule.


### PR DESCRIPTION
If you like this, we can probably get rid of the config option and the $delim variable in auth.php

This has caused some serious headaches at my organization and some cohorts were created with a line break at the end. This meant that users were being put into a new garbage cohort instead of the correct one and not getting the correct rules applied to them.

This patch removes platform EOL characters from the equation. It will split the config on any type of linebreak without trailing garbage.